### PR TITLE
fixed random number for instruction CXNN

### DIFF
--- a/src/chip8.cpp
+++ b/src/chip8.cpp
@@ -305,7 +305,7 @@ void Chip8::emulate_cycle() {
 
         // CXNN - Sets VX to a random number, masked by NN.
         case 0xC000:
-            V[(opcode & 0x0F00) >> 8] = (rand() % 0xFF) & (opcode & 0x00FF);
+            V[(opcode & 0x0F00) >> 8] = (rand() % (0xFF + 1)) & (opcode & 0x00FF);
             pc += 2;
             break;
 


### PR DESCRIPTION
`rand() % 0xFF` will get all numbers between and including 0..254. However, the true implementation of a Chip8 instruction for CXNN should be 0..255. This fixes that. This references the issue #1 